### PR TITLE
Change MediatorOptions to public so consumers can access it

### DIFF
--- a/src/MakoIoT.Device.Services.Mediator/MakoIoT.Device.Services.Mediator.nfproj
+++ b/src/MakoIoT.Device.Services.Mediator/MakoIoT.Device.Services.Mediator.nfproj
@@ -25,6 +25,7 @@
     <Compile Include="IMediator.cs" />
     <Compile Include="Mediator.cs" />
     <Compile Include="MediatorOptions.cs" />
+    <Compile Include="MediatorOptionsSubscriber.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/src/MakoIoT.Device.Services.Mediator/Mediator.cs
+++ b/src/MakoIoT.Device.Services.Mediator/Mediator.cs
@@ -1,5 +1,4 @@
-﻿using nanoFramework.DependencyInjection;
-using System;
+﻿using System;
 using System.Collections;
 
 namespace MakoIoT.Device.Services.Mediator
@@ -13,17 +12,20 @@ namespace MakoIoT.Device.Services.Mediator
         private readonly Hashtable _subscribers = new();
         private readonly Hashtable _subscriberTypes = new();
 
-        public Mediator(MediatorOptions options, IServiceProvider serviceProvider)
+        public Mediator(IServiceProvider serviceProvider)
         {
-            if (options != null)
+            _serviceProvider = serviceProvider;
+        }
+
+        public Mediator(MediatorOptions options, IServiceProvider serviceProvider): this(serviceProvider)
+        {
+            if (options is not null)
             {
-                foreach (Subscription sub in options.Subscribers)
+                foreach (MediatorOptionsSubscriber subscriber in options.Subscribers)
                 {
-                    Subscribe(sub.EventType, sub.SubscriberType);
+                    Subscribe(subscriber.EventType, subscriber.SubscriberType);
                 }
             }
-
-            _serviceProvider = serviceProvider;
         }
 
         /// <inheritdoc />

--- a/src/MakoIoT.Device.Services.Mediator/MediatorOptions.cs
+++ b/src/MakoIoT.Device.Services.Mediator/MediatorOptions.cs
@@ -5,29 +5,16 @@ namespace MakoIoT.Device.Services.Mediator
 {
     public class MediatorOptions
     {
-        internal readonly ArrayList Subscribers = new();
+        public ArrayList Subscribers { get; } = new();
 
         /// <summary>
         /// Adds subscriber (event handler) to an event.
         /// </summary>
         /// <param name="eventType">Type of the event. The event must implement IEvent interface.</param>
         /// <param name="subscriberType">Type of the subscriber (as registered in DI). The subscriber must implement IEventHandler interface.</param>
-
         public void AddSubscriber(Type eventType, Type subscriberType)
         {
-            Subscribers.Add(new Subscription(eventType, subscriberType));
-        }
-    }
-
-    internal class Subscription
-    {
-        internal Type EventType { get; }
-        internal Type SubscriberType { get; }
-
-        internal Subscription(Type eventType, Type subscriberType)
-        {
-            EventType = eventType;
-            SubscriberType = subscriberType;
+            Subscribers.Add(new MediatorOptionsSubscriber(eventType, subscriberType));
         }
     }
 }

--- a/src/MakoIoT.Device.Services.Mediator/MediatorOptionsSubscriber.cs
+++ b/src/MakoIoT.Device.Services.Mediator/MediatorOptionsSubscriber.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace MakoIoT.Device.Services.Mediator
+{
+    public class MediatorOptionsSubscriber
+    {
+        public Type EventType { get; }
+        public Type SubscriberType { get; }
+
+        internal MediatorOptionsSubscriber(Type eventType, Type subscriberType)
+        {
+            EventType = eventType;
+            SubscriberType = subscriberType;
+        }
+    }
+}


### PR DESCRIPTION
I went to implement my own implementation of `IMediator` and discovered that `MediatorOptions` was internal so I could not access it. This fixes that.